### PR TITLE
removed labeling from edit mode

### DIFF
--- a/src/components/BounceRuleDetailed/Details/index.jsx
+++ b/src/components/BounceRuleDetailed/Details/index.jsx
@@ -129,7 +129,6 @@ export const DetailsContainerEditable = ({
                   id="description"
                   value={description}
                   type="text"
-                  label={description}
                 />
               </TableCell>
             </TableRow>
@@ -160,7 +159,6 @@ export const DetailsContainerEditable = ({
                   id="response_code"
                   value={responseCode}
                   type="number"
-                  label={responseCode}
                 />
               </TableCell>
             </TableRow>
@@ -175,7 +173,6 @@ export const DetailsContainerEditable = ({
                   id="enhanced_code"
                   value={enhancedCode}
                   type="text"
-                  label={enhancedCode}
                 />
               </TableCell>
             </TableRow>
@@ -194,7 +191,6 @@ export const DetailsContainerEditable = ({
                   id="regex"
                   value={regex}
                   type="text"
-                  label={regex}
                 />
               </TableCell>
             </TableRow>
@@ -209,7 +205,6 @@ export const DetailsContainerEditable = ({
                   id="priority"
                   value={priority}
                   type="number"
-                  label={priority}
                 />
               </TableCell>
             </TableRow>
@@ -224,7 +219,6 @@ export const DetailsContainerEditable = ({
                   id="bounce_action"
                   value={bounceAction}
                   type="text"
-                  label={bounceAction}
                 />
               </TableCell>
             </TableRow>


### PR DESCRIPTION
Remove labels from Editing Mode
Removed the secondary labels when editing a bounce rule.
 
- [x] Acceptance Criteria is clear and concise
- [x] Tests written and passing
- [x] Storybook story added (if applicable)
- [x] Include screenshot (if UI change)
- [ ] Code Reviewed

![image](https://user-images.githubusercontent.com/26265748/51161567-c813db80-1847-11e9-9bd6-d4c8a1b48fd8.png)
