### PR TITLE
Bounce Rule Detail Table Styling and Spacing Issues

### DIFF
--- a/src/components/BounceDetailsContainer/Details/index.jsx
+++ b/src/components/BounceDetailsContainer/Details/index.jsx
@@ -68,6 +68,8 @@ const DetailsContainer = ({ currentRule, handleEditClicked }) => {
             </TableRow>
           </TableBody>
         </Table>
+      </div>
+      <div className="detail-info">
         <Table>
           <TableBody>
             <TableRow>

--- a/src/components/BounceDetailsContainer/Details/index.jsx
+++ b/src/components/BounceDetailsContainer/Details/index.jsx
@@ -182,6 +182,8 @@ export const DetailsContainerEditable = ({
             </TableRow>
           </TableBody>
         </Table>
+      </div>
+      <div className="detail-info">
         <Table>
           <TableBody>
             <TableRow>

--- a/src/components/BounceDetailsContainer/Details/index.scss
+++ b/src/components/BounceDetailsContainer/Details/index.scss
@@ -1,5 +1,4 @@
 .detail-container {
-  // display: block;
   justify-content: center;
   align-items: center;
   padding: 5px;

--- a/src/components/BounceDetailsContainer/Details/index.scss
+++ b/src/components/BounceDetailsContainer/Details/index.scss
@@ -18,7 +18,8 @@
   }
 
   td {
-    padding: 15px 10px;
+    padding: 10px;
+    height: 75px;
 
     &.description-cell {
       width: 25%;

--- a/src/components/BounceDetailsContainer/Details/index.scss
+++ b/src/components/BounceDetailsContainer/Details/index.scss
@@ -1,9 +1,18 @@
 .detail-container {
-  display: inline-block;
+  // display: block;
   justify-content: center;
   align-items: center;
   padding: 5px;
   background: #f4f6f7;
+
+  .description-info {
+    width: 100%;
+  }
+
+  .detail-info {
+    display: inline-block;
+    width: 50%;
+  }
 
   .table-fixed {
     table-layout: fixed;
@@ -54,17 +63,5 @@
     .input-text-wrap {
       margin-bottom: 0;
     }
-  }
-
-  .description-info {
-    width: 100%;
-    .table-wrap {
-      margin-bottom: 0;
-    }
-  }
-
-  .detail-info {
-    display: flex;
-    width: 100%;
   }
 }

--- a/src/components/BounceDetailsContainer/__snapshots__/index.test.jsx.snap
+++ b/src/components/BounceDetailsContainer/__snapshots__/index.test.jsx.snap
@@ -199,6 +199,10 @@ exports[`Bounce Rule Detailed should render correctly 1`] = `
                 </tr>
               </tbody>
             </table>
+          </div>
+          <div
+            className="detail-info"
+          >
             <table
               className="table-wrap"
             >


### PR DESCRIPTION
<img width="1277" alt="screen shot 2019-02-20 at 6 32 58 pm" src="https://user-images.githubusercontent.com/11992756/53140292-169c5000-3541-11e9-820c-a0dade513eef.png">

**Trello Ticket Title**: Fix In-line design layout for Safari
Description of changes in this PR: Fixed spacing issues and made the table styling consistent across Safari and Chrome.

- [ ] Acceptance Criteria is clear and concise
- [ ] Tests written and passing
- [ ] Storybook story added (if applicable)
- [x] Include screenshot (if UI change)
- [ ] Code Reviewed
